### PR TITLE
Add docker-py installation in ncp prep

### DIFF
--- a/openshift-ansible-nsx/ncp_prep.yaml
+++ b/openshift-ansible-nsx/ncp_prep.yaml
@@ -1,9 +1,10 @@
 # to run: ansible-playbook -i /PATH/TO/HOSTS/hosts ncp_prep.yaml
 ---
 # run the ncp_prep role on each node of the cluster
-- hosts: OSEv3
-  roles:
-    - ncp_prep
 - hosts: single_master
   roles:
     - nsx_config
+
+- hosts: OSEv3
+  roles:
+    - ncp_prep

--- a/openshift-ansible-nsx/roles/nsx_config/tasks/main.yaml
+++ b/openshift-ansible-nsx/roles/nsx_config/tasks/main.yaml
@@ -1,4 +1,8 @@
 ---
+- name: Install docker-py
+  pip:
+    name: docker-py
+
 - name: Install python-devel
   yum:
     name: python-devel


### PR DESCRIPTION
Added docker-py in case the environment does not have docker installed.
This needs to happend before ncp_prep calls docker module.