### PR TITLE
Removed nsx-node-agent-rbac attribute in playbook

### DIFF
--- a/openshift-ansible-nsx/roles/ncp/defaults/main.yaml
+++ b/openshift-ansible-nsx/roles/ncp/defaults/main.yaml
@@ -10,7 +10,6 @@ nsx_manager_ip: <manager_ip>
 nsx_api_user: <nsx_api_user>
 nsx_api_password: <nsx_api_password>
 ncp_rbac_yaml_url: <ncp_rbac_yaml_url>
-nsx_node_agent_rbac_yaml_url: <nsx_node_agent_rbac_yaml_url>
 use_cert: false
 # Uncomment and set correct path for the following two lines if use_cert is set to true
 # nsx_api_cert_file: <nsx_api_cert_path>

--- a/openshift-ansible-nsx/roles/ncp/tasks/main.yaml
+++ b/openshift-ansible-nsx/roles/ncp/tasks/main.yaml
@@ -30,21 +30,6 @@
 - name: Apply ncp-rbac
   command: oc apply -f /tmp/ncp-rbac.yml
 
-- name: Download nsx-node-agent-rbac
-  get_url:
-    url: "{{ nsx_node_agent_rbac_yaml_url }}"
-    dest: /tmp/nsx-node-agent-rbac.yml
-    force: yes
-
-- name: Change API version for nsx-node-agent-rbac
-  replace:
-    path: /tmp/nsx-node-agent-rbac.yml
-    regexp: "^apiVersion: rbac.authorization.k8s.io/v1beta1"
-    replace: "apiVersion: v1"
-
-- name: Apply nsx-node-agent-rbac
-  command: oc apply -f /tmp/nsx-node-agent-rbac.yml
-
 - name: check if /etc/nsx-ujo dir exists
   stat:
     path: /etc/nsx-ujo


### PR DESCRIPTION
In DGO2, nsx-node-agent-rbac file has been removed.
It's now merged into the same rbac file of nsx-ncp-rbac.yaml.
Removing the lines that are no longer needed.