### PR TITLE
Fix gcc issue required for vmware-nsxlib

### DIFF
--- a/openshift-ansible-nsx/roles/nsx_config/tasks/main.yaml
+++ b/openshift-ansible-nsx/roles/nsx_config/tasks/main.yaml
@@ -4,6 +4,11 @@
     name: python-devel
     state: latest
 
+- name: Install gcc
+  yum:
+    name: gcc
+    state: present
+
 - name: Install virtualenv
   pip:
     name: virtualenv


### PR DESCRIPTION
TASK [nsx_config : Install vmware-nsxlib] Failing because of gcc not present in jumphost. Adding installation task will fix this issue.
