### PR TITLE
Remove VC components for BMC setup

### DIFF
--- a/openshift-ansible-nsx/roles/nsx_config/tasks/main.yaml
+++ b/openshift-ansible-nsx/roles/nsx_config/tasks/main.yaml
@@ -42,16 +42,26 @@
   file:
     path: /tmp/vsphere-automation-sdk-python/
     state: absent
-  when: dep_info.failed == true and BMC == false
+  when: BMC == false
 
 - name: NSX management plane resource configuration with cert
   command: "/tmp/nsx-config/bin/python '{{ playbook_dir }}'/../nsx_config.py --cert {{ nsx_cert_file_path }} --BMC {{ BMC }} --tn {{ nsx_transport_node_names }} --mp {{ nsx_manager_ip }} --k8scluster {{ cluster_name }} --edge_cluster {{ nsx_edge_cluster_name }} --tz {{ nsx_transport_zone_name }} --t0 {{ nsx_t0_router_name }} --pod_ipblock_name {{ pod_ipblock_name }} --pod_ipblock_cidr {{ pod_ipblock_cidr }} --snat_ippool_name {{ snat_ippool_name }} --snat_ippool_cidr {{ snat_ippool_cidr }} --start_range {{ start_range }} --end_range {{ end_range }} --node {{ os_node_name_list }} --node_ls {{ nsx_node_ls_name }} --node_lr {{ nsx_node_lr_name }} --node_network_cidr {{ node_network_cidr }} --vc_host {{ vc_host }} --vc_user {{ vc_user }} --vc_password {{ vc_password }} --vms {{ vms }}"
-  when: perform_nsx_config == True and use_cert == True
+  when: perform_nsx_config == True and use_cert == True and BMC == false
   register: nsx_config_result
 
 - name: NSX management plane resource configuration with user name
   command: "/tmp/nsx-config/bin/python '{{ playbook_dir }}'/../nsx_config.py --user {{ nsx_api_user }} --password {{ nsx_api_password }} --BMC {{ BMC }} --tn {{ nsx_transport_node_names }} --mp {{ nsx_manager_ip }} --k8scluster {{ cluster_name }} --edge_cluster {{ nsx_edge_cluster_name }} --tz {{ nsx_transport_zone_name }} --t0 {{ nsx_t0_router_name }} --pod_ipblock_name {{ pod_ipblock_name }} --pod_ipblock_cidr {{ pod_ipblock_cidr }} --snat_ippool_name {{ snat_ippool_name }} --snat_ippool_cidr {{ snat_ippool_cidr }} --start_range {{ start_range }} --end_range {{ end_range }} --node {{ os_node_name_list }} --node_ls {{ nsx_node_ls_name }} --node_lr {{ nsx_node_lr_name }} --node_network_cidr {{ node_network_cidr }} --vc_host {{ vc_host }} --vc_user {{ vc_user }} --vc_password {{ vc_password }} --vms {{ vms }}"
-  when: perform_nsx_config == True and use_cert == False
+  when: perform_nsx_config == True and use_cert == False and BMC == false
+  register: nsx_config_result
+
+- name: BMC NSX management plane resource configuration with cert
+  command: "/tmp/nsx-config/bin/python '{{ playbook_dir }}'/../nsx_config.py --cert {{ nsx_cert_file_path }} --BMC {{ BMC }} --tn {{ nsx_transport_node_names }} --mp {{ nsx_manager_ip }} --k8scluster {{ cluster_name }} --edge_cluster {{ nsx_edge_cluster_name }} --tz {{ nsx_transport_zone_name }} --t0 {{ nsx_t0_router_name }} --pod_ipblock_name {{ pod_ipblock_name }} --pod_ipblock_cidr {{ pod_ipblock_cidr }} --snat_ippool_name {{ snat_ippool_name }} --snat_ippool_cidr {{ snat_ippool_cidr }} --start_range {{ start_range }} --end_range {{ end_range }}"
+  when: perform_nsx_config == True and use_cert == True and BMC != false
+  register: nsx_config_result
+
+- name: BMC NSX management plane resource configuration with user name
+  command: "/tmp/nsx-config/bin/python '{{ playbook_dir }}'/../nsx_config.py --user {{ nsx_api_user }} --password {{ nsx_api_password }} --BMC {{ BMC }} --tn {{ nsx_transport_node_names }} --mp {{ nsx_manager_ip }} --k8scluster {{ cluster_name }} --edge_cluster {{ nsx_edge_cluster_name }} --tz {{ nsx_transport_zone_name }} --t0 {{ nsx_t0_router_name }} --pod_ipblock_name {{ pod_ipblock_name }} --pod_ipblock_cidr {{ pod_ipblock_cidr }} --snat_ippool_name {{ snat_ippool_name }} --snat_ippool_cidr {{ snat_ippool_cidr }} --start_range {{ start_range }} --end_range {{ end_range }}"
+  when: perform_nsx_config == True and use_cert == False and BMC != false
   register: nsx_config_result
 
 - name: remove nsx-config virtualenv

--- a/openshift-ansible-nsx/vars/global.yaml
+++ b/openshift-ansible-nsx/vars/global.yaml
@@ -19,7 +19,7 @@ nsx_manager_ip: 10.161.115.70
 nsx_edge_cluster_name: edgecluster1
 nsx_transport_zone_name: 1-transportzone-460
 
-# No need to specify if BMC is set to false
+# No need to specify if BMC is set to true
 os_node_name_list: osmaster
 node_network_cidr: 172.10.0.1/16
 vc_host: 10.161.107.101


### PR DESCRIPTION
Here is fix.
1.
Update comment 
No need to specify if BMC is set to false
To
No need to specify if BMC is set to True

2.
Below task failed
TASK [nsx_config : NSX management plane resource configuration with user name] ************************************************************************************************************
fatal: [fvt1796-246-207]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'os_node_name_list' is undefined\n\nThe error appears to have been in '/root/nsx-integration-for-openshift/openshift-ansible-nsx/roles/nsx_config/tasks/main.yaml': line 57, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: NSX management plane resource configuration with user name\n  ^ here\n"}
 
Above error is for all these variables.
os_node_name_list:
nsx_node_ls_name:
nsx_node_lr_name:
node_network_cidr:
vc_host:
vc_user:
vc_password:
vms:
 
Adding BMC flag and removing these params from command line of that task worked.